### PR TITLE
Fix grafna operator so it works with custom-ca

### DIFF
--- a/charts/deploy/templates/grafana.yaml
+++ b/charts/deploy/templates/grafana.yaml
@@ -32,6 +32,7 @@ spec:
         - '-openshift-service-account=grafana-serviceaccount'
         - '-openshift-ca=/etc/pki/tls/cert.pem'
         - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        - '-openshift-ca=/etc/grafana-configmaps/ocp-injected-certs/ca-bundle.crt'
         - '-skip-auth-regex=^/metrics'
       image: 'quay.io/openshift/origin-oauth-proxy:4.2'
       name: grafana-proxy
@@ -49,6 +50,8 @@ spec:
   secrets:
     - grafana-k8s-tls
     - grafana-k8s-proxy
+  configMaps:
+    - ocp-injected-certs
   service:
     ports:
       - name: grafana-proxy

--- a/charts/deploy/templates/ocp-injected-certs.yml
+++ b/charts/deploy/templates/ocp-injected-certs.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: ocp-injected-certs


### PR DESCRIPTION
Due to what happens when you add a custom certificate to OCP you need to add the root ca to the operator.
Explained here: https://docs.openshift.com/container-platform/4.4/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki

It also works when you haven't added a custom ca :)
