### PR TITLE
Adding event access to grafana-operator

### DIFF
--- a/charts/deploy/charts/grafana-operator/templates/cluster_role.yaml
+++ b/charts/deploy/charts/grafana-operator/templates/cluster_role.yaml
@@ -21,3 +21,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch


### PR DESCRIPTION
Without it can't update events in other namespaces then it's deployed to.

Else you will se errors like this:
Source:v1.EventSource{Component:"controller_grafanadashboard", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbfb9d18da262280d, ext:164866398662608, loc:(*time.Location)(0x207bd60)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbfb9d18da262280d, ext:164866398662608, loc:(*time.Location)(0x207bd60)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:grafana:grafana-operator" cannot create resource "events" in API group "" in the namespace "argocd"' (will not retry!)
